### PR TITLE
Fix reading partial objects

### DIFF
--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -736,6 +736,8 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
             {
                 // do read meta header not in given transfer syntax (always Little Endian Explicit)
                 errorFlag = metaInfo->read(inStream, EXS_Unknown, glenc, maxReadLength);
+	        if (errorFlag.bad())
+		    return errorFlag;
             }
 
             // determine xfer from tag (0002,0010) in the meta header

--- a/dcmdata/libsrc/dcmetinf.cc
+++ b/dcmdata/libsrc/dcmetinf.cc
@@ -407,7 +407,8 @@ OFCondition DcmMetaInfo::read(DcmInputStream &inStream,
         errorFlag = EC_IllegalCall;
     else
     {
-        Xfer = xfer;
+        if (getTransferState() == ERW_init)
+            Xfer = xfer;
         E_TransferSyntax newxfer = xfer;
         // figure out if the stream reported an error
         errorFlag = inStream.status();
@@ -429,7 +430,8 @@ OFCondition DcmMetaInfo::read(DcmInputStream &inStream,
                     fStartPosition = inStream.tell();
                     setLengthField(0);
                 }
-            }
+            } else
+	          newxfer = Xfer; // use stored transfer syntax which was determined from preamble
             if (getTransferState() == ERW_inWork && getLengthField() == 0)
             {
                 if (inStream.avail() < OFstatic_cast(offile_off_t, DCM_GroupLengthElementLength))


### PR DESCRIPTION
Following 2 commits fix reading DcmFileFormat when that partially available in input stream.